### PR TITLE
Add fromGetters

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,25 @@ async asyncIncrement({ commit }: { commit: Function }) {
 
 Wrap your mutations and actions with unique namespace by vuex-aggregate provided APIs.
 `fromMutations` is for mutations, `fromActions` is for actions.
-`namespace` must to be align modulename.
+`namespace` must to be match modulename.
 
 ```javascript
 import { fromMutations, fromActions } from 'vuex-aggregate'
 
 export const namespace = 'counter'
+
+// ______________________________________________________
+//
+// @ Getters
+
+const getters = {
+  expo(state: CounterState): (amount: number) => number {
+    return (amount: number) => {
+      return state.count ** amount
+    }
+  }
+}
+export const { proxyGetters } = fromGetters(getters, namespace)
 
 // ______________________________________________________
 //

--- a/examples/src/store/index.ts
+++ b/examples/src/store/index.ts
@@ -13,6 +13,7 @@ export interface Store {
   state: StoreState
   commit: Function
   dispatch: Function
+  getters: any
 }
 export interface BoundsStore {
   $store: Store

--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -1,4 +1,10 @@
-import { fromMutations, fromActions, fromGetters, Injects, Modeler } from '../../../../src'
+import {
+  fromMutations,
+  fromActions,
+  fromGetters,
+  Injects,
+  Modeler
+} from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
@@ -15,7 +21,7 @@ export interface CounterState {
 
 const CounterModel: Modeler<CounterState> = injects => ({
   count: 0,
-  name: 'my name',
+  name: 'unknown',
   isRunningAutoIncrement: false,
   ...injects
 })
@@ -25,14 +31,22 @@ const CounterModel: Modeler<CounterState> = injects => ({
 // @ Getters
 
 const getters = {
-  autoIncrementLabel(state: CounterState): string {
-    const flag = state.isRunningAutoIncrement
-    return flag ? 'true' : 'false'
+  countLabel(state: CounterState): (unit: string) => string {
+    return (unit: string) => {
+      return `${state.count} ${unit}`
+    }
   },
   expo(state: CounterState): (amount: number) => number {
     return (amount: number) => {
       return state.count ** amount
     }
+  },
+  autoIncrementLabel(state: CounterState): string {
+    const flag = state.isRunningAutoIncrement
+    return flag ? 'true' : 'false'
+  },
+  nameLabel(state: CounterState): string {
+    return `my name is ${state.name}`
   }
 }
 

--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -1,4 +1,4 @@
-import { fromMutations, fromActions, Injects, Modeler } from 'vuex-aggregate'
+import { fromMutations, fromActions, fromGetters, Injects, Modeler } from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
@@ -19,6 +19,24 @@ const CounterModel: Modeler<CounterState> = injects => ({
   isRunningAutoIncrement: false,
   ...injects
 })
+
+// ______________________________________________________
+//
+// @ Getters
+
+const getters = {
+  autoIncrementLabel(state: CounterState): string {
+    const flag = state.isRunningAutoIncrement
+    return flag ? 'true' : 'false'
+  },
+  expo(state: CounterState): (amount: number) => number {
+    return (amount: number) => {
+      return state.count ** amount
+    }
+  }
+}
+
+export const { proxyGetters } = fromGetters(getters, namespace)
 
 // ______________________________________________________
 //
@@ -72,6 +90,7 @@ export const { dispatchers, actionTypes } = fromActions(actions, namespace)
 export const CounterModule = (injects?: Injects<CounterState>) => ({
   namespaced: true, // Required
   state: CounterModel(injects),
+  getters,
   mutations,
   actions
 })

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <p>count = {{count}}</p>
+    <p>expo2 = {{expo2}}</p>
     <p>isRunningAutoIncrement = {{autoIncrementLabel}}</p>
     <p>name = {{name}}</p>
     <div>
@@ -17,7 +18,7 @@
 <script lang='ts'>
 import Vue from 'vue'
 import { BoundsStore } from '../store/index'
-import { committers, dispatchers } from '../store/modules/counter'
+import { committers, dispatchers, proxyGetters } from '../store/modules/counter'
 
 const computed: ThisType<BoundsStore> = {
   count () {
@@ -26,9 +27,11 @@ const computed: ThisType<BoundsStore> = {
   name () {
     return this.$store.state.counter.name
   },
+  expo2 () {
+    return proxyGetters.expo(this.$store.getters, 2)
+  },
   autoIncrementLabel() {
-    const flag = this.$store.state.counter.isRunningAutoIncrement
-    return flag ? 'true' : 'false'
+    return proxyGetters.autoIncrementLabel(this.$store.getters)
   }
 }
 const methods: ThisType<BoundsStore> = {

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <p>count = {{count}}</p>
+    <p>count = {{countLabel}}</p>
     <p>expo2 = {{expo2}}</p>
     <p>isRunningAutoIncrement = {{autoIncrementLabel}}</p>
-    <p>name = {{name}}</p>
+    <p>name = {{nameLabel}}</p>
     <div>
       <button @click="increment()">+1</button>
       <button @click="asyncIncrement(1000)">asyncIncrement</button>
@@ -21,11 +21,11 @@ import { BoundsStore } from '../store/index'
 import { committers, dispatchers, proxyGetters } from '../store/modules/counter'
 
 const computed: ThisType<BoundsStore> = {
-  count () {
-    return this.$store.state.counter.count
+  countLabel () {
+    return proxyGetters.countLabel(this.$store.getters, 'pt')
   },
-  name () {
-    return this.$store.state.counter.name
+  nameLabel () {
+    return proxyGetters.nameLabel(this.$store.getters)
   },
   expo2 () {
     return proxyGetters.expo(this.$store.getters, 2)
@@ -34,6 +34,7 @@ const computed: ThisType<BoundsStore> = {
     return proxyGetters.autoIncrementLabel(this.$store.getters)
   }
 }
+
 const methods: ThisType<BoundsStore> = {
   increment () {
     committers.increment(this.$store.commit)

--- a/src/fromActions.ts
+++ b/src/fromActions.ts
@@ -1,10 +1,9 @@
+import { Types, KeyMap } from '../typings/utils.d'
 import {
-  KeyMap,
   Actions,
-  Types,
   Dispatchers,
   FromActionsReturn
-} from '../typings/index.d'
+} from '../typings/fromActions.d'
 
 const namespaced: KeyMap = {}
 

--- a/src/fromGetters.ts
+++ b/src/fromGetters.ts
@@ -1,0 +1,37 @@
+import { KeyMap } from '../typings/utils.d'
+import {
+  Getters,
+  ProxyGetters,
+  FromGettersReturn
+} from '../typings/fromGetters.d'
+
+const namespaced: KeyMap = {}
+
+function fromGetters<G extends KeyMap & Getters<G>>(
+  getters: G,
+  namespace: string
+): FromGettersReturn<G> {
+  if (
+    namespaced[namespace] !== undefined &&
+    process.env.NODE_ENV !== 'development'
+  ) {
+    throw new Error(
+      `vuex-aggregate: conflict fromGetters namespace -> ${namespace}`
+    )
+  } else {
+    namespaced[namespace] = namespace
+  }
+  const proxyGetters: KeyMap = {}
+  Object.keys(getters).forEach(key => {
+    const getterKey = `${namespace}/${key}`
+    proxyGetters[key] = (state: KeyMap, args?: any) => {
+      if (typeof state[getterKey] !== 'function') return state[getterKey]
+      return state[getterKey](args)
+    }
+  })
+  return {
+    proxyGetters: proxyGetters as ProxyGetters<G>
+  }
+}
+
+export { fromGetters }

--- a/src/fromMutations.ts
+++ b/src/fromMutations.ts
@@ -1,10 +1,9 @@
+import { Types, KeyMap } from '../typings/utils.d'
 import {
-  KeyMap,
   Mutations,
-  Types,
   Committers,
   FromMutationsReturn
-} from '../typings/index.d'
+} from '../typings/fromMutations.d'
 
 const namespaced: KeyMap = {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Injects, Modeler } from './utils'
+import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
 import { fromActions } from './fromActions'
-export { fromMutations, fromActions, Injects, Modeler }
+export { fromGetters, fromMutations, fromActions, Injects, Modeler }

--- a/typings/fromActions.d.ts
+++ b/typings/fromActions.d.ts
@@ -1,0 +1,33 @@
+import { KeyMap, A2, Types } from './utils.d'
+
+// ______________________________________________________
+//
+// @ fromActions
+
+// IN
+type AC<T> = (context: any) => Promise<any>
+type ACPL<T> = (context: any, payload: A2<T>) => Promise<any>
+type Action<T> = AC<T> | ACPL<T>
+type Actions<T> = { [K in keyof T]: Action<T[K]> }
+
+// OUT
+type DP<T> = (diapatch: Function) => Promise<any>
+type DPPL<T> = (diapatch: Function, payload: A2<T>) => Promise<any>
+type Dispatcher<T> = T extends AC<T> ? DP<T> : DPPL<T>
+type Dispatchers<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
+interface FromActionsReturn<A> {
+  readonly actionTypes: Types<A>
+  readonly dispatchers: Dispatchers<A>
+}
+
+// DECL
+declare function fromActions<T extends KeyMap & Actions<T>>(
+  actions: T,
+  namespace: string
+): FromActionsReturn<T>
+
+// ______________________________________________________
+//
+// @ exports
+
+export { Actions, Dispatchers, FromActionsReturn, fromActions }

--- a/typings/fromGetters.d.ts
+++ b/typings/fromGetters.d.ts
@@ -5,8 +5,8 @@ import { KeyMap, RA1, R, RR, Types } from './utils.d'
 // @ fromGetters
 
 // IN
-type GT<T> = (getters: any) => any
-type GTR<T> = (getters: any) => (args: any) => any
+type GT<T> = (getters: any, contextGetters?: any) => any
+type GTR<T> = (getters: any, contextGetters?: any) => (args: any) => any
 type Getter<T> = GT<T> | GTR<T>
 type Getters<T> = { [K in keyof T]: Getter<T[K]> }
 

--- a/typings/fromGetters.d.ts
+++ b/typings/fromGetters.d.ts
@@ -1,0 +1,32 @@
+import { KeyMap, RA1, R, RR, Types } from './utils.d'
+
+// ______________________________________________________
+//
+// @ fromGetters
+
+// IN
+type GT<T> = (getters: any) => any
+type GTR<T> = (getters: any) => (args: any) => any
+type Getter<T> = GT<T> | GTR<T>
+type Getters<T> = { [K in keyof T]: Getter<T[K]> }
+
+// OUT
+type PGT<T> = (getters: any) => R<T>
+type PGTR<T> = (getters: any, args: RA1<T>) => RR<T>
+type ProxyGetter<T> = T extends GTR<T> ? PGTR<T> : PGT<T>
+type ProxyGetters<T> = { readonly [K in keyof T]: ProxyGetter<T[K]> }
+interface FromGettersReturn<G> {
+  readonly proxyGetters: ProxyGetters<G>
+}
+
+// DECL
+declare function fromGetters<T extends KeyMap & Getters<T>>(
+  getters: T,
+  namespace: string
+): FromGettersReturn<T>
+
+// ______________________________________________________
+//
+// @ exports
+
+export { Getters, ProxyGetters, FromGettersReturn, fromGetters }

--- a/typings/fromMutations.d.ts
+++ b/typings/fromMutations.d.ts
@@ -1,0 +1,33 @@
+import { KeyMap, A1, A2, Types } from './utils.d'
+
+// ______________________________________________________
+//
+// @ fromMutations
+
+// IN
+type MT<T> = (state: A1<T>) => void
+type MTPL<T> = (state: A1<T>, payload: A2<T>) => void
+type Mutation<T> = MT<T> | MTPL<T>
+type Mutations<T> = { [K in keyof T]: Mutation<T[K]> }
+
+// OUT
+type CM<T> = (commit: Function) => void
+type CMPL<T> = (commit: Function, payload: A2<T>) => void
+type Committer<T> = T extends MT<T> ? CM<T> : CMPL<T>
+type Committers<T> = { readonly [K in keyof T]: Committer<T[K]> }
+interface FromMutationsReturn<M> {
+  readonly mutationTypes: Types<M>
+  readonly committers: Committers<M>
+}
+
+// DECL
+declare function fromMutations<T extends KeyMap & Mutations<T>>(
+  mutations: T,
+  namespace: string
+): FromMutationsReturn<T>
+
+// ______________________________________________________
+//
+// @ exports
+
+export { Mutations, Committers, FromMutationsReturn, fromMutations }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,54 +1,10 @@
-type KeyMap = { [K: string]: any }
-type A1<T> = T extends (a1: infer I, ...rest: any[]) => any ? I : never
-type A2<T> = T extends (a1: any, a2: infer I, ...rest: any[]) => any ? I : never
-type MT<T> = (state: A1<T>) => void
-type CM<T> = (commit: Function) => void
-type AC<T> = (context: any) => Promise<any>
-type DP<T> = (diapatch: Function) => Promise<any>
-type MTPL<T> = (state: A1<T>, payload: A2<T>) => void
-type CMPL<T> = (commit: Function, payload: A2<T>) => void
-type ACPL<T> = (context: any, payload: A2<T>) => Promise<any>
-type DPPL<T> = (diapatch: Function, payload: A2<T>) => Promise<any>
-type Mutation<T> = MT<T> | MTPL<T>
-type Action<T> = AC<T> | ACPL<T>
-type Committer<T> = T extends MT<T> ? CM<T> : CMPL<T>
-type Dispatcher<T> = T extends AC<T> ? DP<T> : DPPL<T>
-type Types<T> = { readonly [K in keyof T]: string }
-type Mutations<T> = { readonly [K in keyof T]: Mutation<T[K]> }
-type Actions<T> = { readonly [K in keyof T]: Action<T[K]> }
-type Committers<T> = { readonly [K in keyof T]: Committer<T[K]> }
-type Dispatchers<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
-type Injects<T> = { [P in keyof T]?: T[P] }
-type Modeler<T> = (injects?: Injects<T>) => T
+import { Injects, Modeler } from './utils'
+import { fromGetters } from './fromGetters'
+import { fromMutations } from './fromMutations'
+import { fromActions } from './fromActions'
 
-interface FromMutationsReturn<M> {
-  readonly mutationTypes: Types<M>
-  readonly committers: Committers<M>
-}
-interface FromActionsReturn<A> {
-  readonly actionTypes: Types<A>
-  readonly dispatchers: Dispatchers<A>
-}
-declare function fromMutations<M extends KeyMap & Mutations<M>>(
-  mutations: M,
-  namespace: string
-): FromMutationsReturn<M>
-declare function fromActions<A extends KeyMap & Actions<A>>(
-  actions: A,
-  namespace: string
-): FromActionsReturn<A>
+// ______________________________________________________
+//
+// @ exports
 
-export {
-  KeyMap,
-  Types,
-  Mutations,
-  Actions,
-  Committers,
-  Dispatchers,
-  Injects,
-  Modeler,
-  FromMutationsReturn,
-  FromActionsReturn,
-  fromMutations,
-  fromActions
-}
+export { Injects, Modeler, fromGetters, fromMutations, fromActions }

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -4,7 +4,9 @@
 
 type KeyMap = { [K: string]: any }
 type R<T> = T extends (...rest: any[]) => infer I ? I : never
-type RR<T> = T extends (...rest: any[]) => (...rest: any[]) => infer I ? I : never
+type RR<T> = T extends (...rest: any[]) => (...rest: any[]) => infer I
+  ? I
+  : never
 
 type A1<T> = T extends (a1: infer I, ...rest: any[]) => any ? I : never
 type A2<T> = T extends (a1: any, a2: infer I, ...rest: any[]) => any ? I : never

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -1,0 +1,21 @@
+// ______________________________________________________
+//
+// @ utils
+
+type KeyMap = { [K: string]: any }
+type R<T> = T extends (...rest: any[]) => infer I ? I : never
+type RR<T> = T extends (...rest: any[]) => (...rest: any[]) => infer I ? I : never
+
+type A1<T> = T extends (a1: infer I, ...rest: any[]) => any ? I : never
+type A2<T> = T extends (a1: any, a2: infer I, ...rest: any[]) => any ? I : never
+type RA1<T> = T extends (...rest: any[]) => (a1: infer I) => any ? I : never
+
+type Types<T> = { readonly [K in keyof T]: string }
+type Injects<T> = { [P in keyof T]?: T[P] }
+type Modeler<T> = (injects?: Injects<T>) => T
+
+// ______________________________________________________
+//
+// @ exports
+
+export { KeyMap, R, A1, A2, RR, RA1, Types, Injects, Modeler }


### PR DESCRIPTION
# Available Feature

### @ examples/src/store/modules/counter.ts

```javascript
import { fromGetters } from 'vuex-aggregate'

// ______________________________________________________
//
// @ Getters

const getters = {
  countLabel(state: CounterState): (unit: string) => string {
    return (unit: string) => {
      return `${state.count} ${unit}`
    }
  },
  expo(state: CounterState): (amount: number) => number {
    return (amount: number) => {
      return state.count ** amount
    }
  },
  autoIncrementLabel(state: CounterState): string {
    const flag = state.isRunningAutoIncrement
    return flag ? 'true' : 'false'
  },
  nameLabel(state: CounterState): string {
    return `my name is ${state.name}`
  }
}

export const { proxyGetters } = fromGetters(getters, namespace)

```

### @ examples/src/vue/app.vue

```javascript
import { proxyGetters } from '../store/modules/counter'

const computed: ThisType<BoundsStore> = {
  countLabel () {
    return proxyGetters.countLabel(this.$store.getters, 'pt')
  },
  nameLabel () {
    return proxyGetters.nameLabel(this.$store.getters)
  },
  expo2 () {
    return proxyGetters.expo(this.$store.getters, 2)
  },
  autoIncrementLabel() {
    return proxyGetters.autoIncrementLabel(this.$store.getters)
  }
```

# Next Feature

Comming TypeScript3.0, will be able to use tuple of argument.
then, we will be able to use multiple argument for return function.

```javascript
expoLabel(state: CounterState): (amount: number, unit: string) => string {
    return (amount: number, unit: string) => {
      return `${state.count ** amount} ${unit}`
    }
  }
```