### PR TITLE
Add map helper proxy

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "start": "webpack-dev-server --mode=development",
-    "prettier": "prettier \"src/**/*.ts\" \"types/**/*.ts\" --write"
+    "prettier": "prettier \"src/**/*.ts\" \"src/**/*.vue\" \"types/**/*.ts\" --write"
   },
   "dependencies": {
     "vue": "^2.5.16",

--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -4,16 +4,16 @@ import {
   fromGetters,
   Injects,
   Modeler
-} from 'vuex-aggregate'
+} from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
 //
 // @ Model
 
-export const namespace = 'counter'
+const namespace = 'counter'
 
-export interface CounterState {
+interface CounterState {
   count: number
   name: string
   isRunningAutoIncrement: boolean
@@ -49,8 +49,7 @@ const getters = {
     return `my name is ${state.name}`
   }
 }
-
-export const { proxyGetters } = fromGetters(getters, namespace)
+const { proxyGetters, proxyMapGetters } = fromGetters(getters, namespace)
 
 // ______________________________________________________
 //
@@ -59,6 +58,9 @@ export const { proxyGetters } = fromGetters(getters, namespace)
 const mutations = {
   increment(state: CounterState): void {
     state.count++
+  },
+  decrement(state: CounterState): void {
+    state.count--
   },
   setCount(state: CounterState, count: number): void {
     state.count = count
@@ -70,8 +72,10 @@ const mutations = {
     state.isRunningAutoIncrement = flag
   }
 }
-
-export const { committers, mutationTypes } = fromMutations(mutations, namespace)
+const { committers, mutationTypes, proxyMapMutations } = fromMutations(
+  mutations,
+  namespace
+)
 
 // ______________________________________________________
 //
@@ -94,17 +98,32 @@ const actions = {
     }
   }
 }
-
-export const { dispatchers, actionTypes } = fromActions(actions, namespace)
+const { dispatchers, actionTypes, proxyMapActions } = fromActions(
+  actions,
+  namespace
+)
 
 // ______________________________________________________
 //
 // @ ModuleFactory
 
-export const CounterModule = (injects?: Injects<CounterState>) => ({
+const CounterModule = (injects?: Injects<CounterState>) => ({
   namespaced: true, // Required
   state: CounterModel(injects),
   getters,
   mutations,
   actions
 })
+
+export {
+  CounterState,
+  CounterModule,
+  mutationTypes,
+  actionTypes,
+  committers,
+  dispatchers,
+  proxyGetters,
+  proxyMapGetters,
+  proxyMapMutations,
+  proxyMapActions
+}

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -6,6 +6,7 @@
     <p>name = {{nameLabel}}</p>
     <div>
       <button @click="increment()">+1</button>
+      <button @click="decrement()">-1</button>
       <button @click="asyncIncrement(1000)">asyncIncrement</button>
       <button @click="toggleAutoIncrement(100)">toggleAutoIncrement</button>
     </div>
@@ -17,35 +18,34 @@
 
 <script lang='ts'>
 import Vue from 'vue'
+import { mapGetters, mapMutations, mapActions } from 'vuex'
 import { BoundsStore } from '../store/index'
-import { committers, dispatchers, proxyGetters } from '../store/modules/counter'
+import {
+  dispatchers,
+  committers,
+  proxyGetters,
+  proxyMapGetters,
+  proxyMapMutations,
+  proxyMapActions
+} from '../store/modules/counter'
 
 const computed: ThisType<BoundsStore> = {
-  countLabel () {
+  countLabel() {
     return proxyGetters.countLabel(this.$store.getters, 'pt')
   },
-  nameLabel () {
-    return proxyGetters.nameLabel(this.$store.getters)
-  },
-  expo2 () {
+  expo2() {
     return proxyGetters.expo(this.$store.getters, 2)
   },
-  autoIncrementLabel() {
-    return proxyGetters.autoIncrementLabel(this.$store.getters)
-  }
+  ...proxyMapGetters(mapGetters, ['nameLabel', 'autoIncrementLabel'])
 }
 
 const methods: ThisType<BoundsStore> = {
-  increment () {
-    committers.increment(this.$store.commit)
-  },
-  setName (value: string) {
+  ...proxyMapMutations(mapMutations, ['increment', 'decrement']),
+  setName(value: string) {
     committers.setName(this.$store.commit, value)
   },
-  asyncIncrement (duration: number) {
-    dispatchers.asyncIncrement(this.$store.dispatch, duration)
-  },
-  toggleAutoIncrement (duration: number) {
+  ...proxyMapActions(mapActions, ['asyncIncrement']),
+  toggleAutoIncrement(duration: number) {
     const flag = !this.$store.state.counter.isRunningAutoIncrement
     dispatchers.toggleAutoIncrement(this.$store.dispatch, { duration, flag })
   }

--- a/src/fromActions.ts
+++ b/src/fromActions.ts
@@ -1,16 +1,17 @@
-import { Types, KeyMap } from '../typings/utils.d'
+import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
 import {
   Actions,
   Dispatchers,
+  ProxyMapActions,
   FromActionsReturn
 } from '../typings/fromActions.d'
 
 const namespaced: KeyMap = {}
 
-function fromActions<A extends KeyMap & Actions<A>>(
-  actions: A,
+function fromActions<T extends KeyMap & Actions<T>>(
+  actions: T,
   namespace: string
-): FromActionsReturn<A> {
+): FromActionsReturn<T> {
   if (
     namespaced[namespace] !== undefined &&
     process.env.NODE_ENV !== 'development'
@@ -30,9 +31,16 @@ function fromActions<A extends KeyMap & Actions<A>>(
       return dispatch(type, payload, { root: true })
     }
   })
+  function proxyMapActions<H extends Function, O extends MapHelperOption<T>>(
+    mapHelper: H,
+    mapHelperOption: O
+  ) {
+    return mapHelper(namespace, mapHelperOption)
+  }
   return {
-    actionTypes: actionTypes as Types<A>,
-    dispatchers: dispatchers as Dispatchers<A>
+    actionTypes: actionTypes as Types<T>,
+    dispatchers: dispatchers as Dispatchers<T>,
+    proxyMapActions: proxyMapActions as ProxyMapActions<T>
   }
 }
 

--- a/src/fromGetters.ts
+++ b/src/fromGetters.ts
@@ -1,16 +1,17 @@
-import { KeyMap } from '../typings/utils.d'
+import { KeyMap, MapHelperOption } from '../typings/utils.d'
 import {
   Getters,
   ProxyGetters,
+  ProxyMapGetters,
   FromGettersReturn
 } from '../typings/fromGetters.d'
 
 const namespaced: KeyMap = {}
 
-function fromGetters<G extends KeyMap & Getters<G>>(
-  getters: G,
+function fromGetters<T extends KeyMap & Getters<T>>(
+  getters: T,
   namespace: string
-): FromGettersReturn<G> {
+): FromGettersReturn<T> {
   if (
     namespaced[namespace] !== undefined &&
     process.env.NODE_ENV !== 'development'
@@ -29,8 +30,15 @@ function fromGetters<G extends KeyMap & Getters<G>>(
       return state[getterKey](args)
     }
   })
+  function proxyMapGetters<H extends Function, O extends MapHelperOption<T>>(
+    mapHelper: H,
+    mapHelperOption: O
+  ) {
+    return mapHelper(namespace, mapHelperOption)
+  }
   return {
-    proxyGetters: proxyGetters as ProxyGetters<G>
+    proxyGetters: proxyGetters as ProxyGetters<T>,
+    proxyMapGetters: proxyMapGetters as ProxyMapGetters<T>
   }
 }
 

--- a/src/fromMutations.ts
+++ b/src/fromMutations.ts
@@ -1,16 +1,17 @@
-import { Types, KeyMap } from '../typings/utils.d'
+import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
 import {
   Mutations,
   Committers,
+  ProxyMapMutations,
   FromMutationsReturn
 } from '../typings/fromMutations.d'
 
 const namespaced: KeyMap = {}
 
-function fromMutations<M extends KeyMap & Mutations<M>>(
-  mutations: M,
+function fromMutations<T extends KeyMap & Mutations<T>>(
+  mutations: T,
   namespace: string
-): FromMutationsReturn<M> {
+): FromMutationsReturn<T> {
   if (
     namespaced[namespace] !== undefined &&
     process.env.NODE_ENV !== 'development'
@@ -30,9 +31,16 @@ function fromMutations<M extends KeyMap & Mutations<M>>(
       return commit(type, payload, { root: true })
     }
   })
+  function proxyMapMutations<H extends Function, O extends MapHelperOption<T>>(
+    mapHelper: H,
+    mapHelperOption: O
+  ) {
+    return mapHelper(namespace, mapHelperOption)
+  }
   return {
-    mutationTypes: mutationTypes as Types<M>,
-    committers: committers as Committers<M>
+    mutationTypes: mutationTypes as Types<T>,
+    committers: committers as Committers<T>,
+    proxyMapMutations: proxyMapMutations as ProxyMapMutations<T>
   }
 }
 

--- a/typings/fromActions.d.ts
+++ b/typings/fromActions.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, A2, Types } from './utils.d'
+import { KeyMap, A2, Types, MapHelperOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -15,9 +15,14 @@ type DP<T> = (diapatch: Function) => Promise<any>
 type DPPL<T> = (diapatch: Function, payload: A2<T>) => Promise<any>
 type Dispatcher<T> = T extends AC<T> ? DP<T> : DPPL<T>
 type Dispatchers<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
+type ProxyMapActions<T> = (
+  mapActions: Function,
+  mapHelperOption: MapHelperOption<T>
+) => any
 interface FromActionsReturn<A> {
   readonly actionTypes: Types<A>
   readonly dispatchers: Dispatchers<A>
+  readonly proxyMapActions: ProxyMapActions<A>
 }
 
 // DECL
@@ -30,4 +35,4 @@ declare function fromActions<T extends KeyMap & Actions<T>>(
 //
 // @ exports
 
-export { Actions, Dispatchers, FromActionsReturn, fromActions }
+export { Actions, Dispatchers, ProxyMapActions, FromActionsReturn, fromActions }

--- a/typings/fromGetters.d.ts
+++ b/typings/fromGetters.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, RA1, R, RR, Types } from './utils.d'
+import { KeyMap, RA1, R, RR, Types, MapHelperOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -15,8 +15,14 @@ type PGT<T> = (getters: any) => R<T>
 type PGTR<T> = (getters: any, args: RA1<T>) => RR<T>
 type ProxyGetter<T> = T extends GTR<T> ? PGTR<T> : PGT<T>
 type ProxyGetters<T> = { readonly [K in keyof T]: ProxyGetter<T[K]> }
+type ProxyMapGetters<T> = (
+  mapGetters: Function,
+  mapHelperOption: MapHelperOption<T>
+) => any
+
 interface FromGettersReturn<G> {
   readonly proxyGetters: ProxyGetters<G>
+  readonly proxyMapGetters: ProxyMapGetters<G>
 }
 
 // DECL
@@ -29,4 +35,10 @@ declare function fromGetters<T extends KeyMap & Getters<T>>(
 //
 // @ exports
 
-export { Getters, ProxyGetters, FromGettersReturn, fromGetters }
+export {
+  Getters,
+  ProxyGetters,
+  ProxyMapGetters,
+  FromGettersReturn,
+  fromGetters
+}

--- a/typings/fromMutations.d.ts
+++ b/typings/fromMutations.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, A1, A2, Types } from './utils.d'
+import { KeyMap, A1, A2, Types, MapHelperOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -15,9 +15,14 @@ type CM<T> = (commit: Function) => void
 type CMPL<T> = (commit: Function, payload: A2<T>) => void
 type Committer<T> = T extends MT<T> ? CM<T> : CMPL<T>
 type Committers<T> = { readonly [K in keyof T]: Committer<T[K]> }
-interface FromMutationsReturn<M> {
-  readonly mutationTypes: Types<M>
-  readonly committers: Committers<M>
+type ProxyMapMutations<T> = (
+  mapMutations: Function,
+  mapHelperOption: MapHelperOption<T>
+) => any
+interface FromMutationsReturn<T> {
+  readonly mutationTypes: Types<T>
+  readonly committers: Committers<T>
+  readonly proxyMapMutations: ProxyMapMutations<T>
 }
 
 // DECL
@@ -30,4 +35,10 @@ declare function fromMutations<T extends KeyMap & Mutations<T>>(
 //
 // @ exports
 
-export { Mutations, Committers, FromMutationsReturn, fromMutations }
+export {
+  Mutations,
+  Committers,
+  ProxyMapMutations,
+  FromMutationsReturn,
+  fromMutations
+}

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -13,6 +13,7 @@ type A2<T> = T extends (a1: any, a2: infer I, ...rest: any[]) => any ? I : never
 type RA1<T> = T extends (...rest: any[]) => (a1: infer I) => any ? I : never
 
 type Types<T> = { readonly [K in keyof T]: string }
+type MapHelperOption<T> = Array<keyof T> | { [k: string]: keyof T }
 type Injects<T> = { [P in keyof T]?: T[P] }
 type Modeler<T> = (injects?: Injects<T>) => T
 
@@ -20,4 +21,4 @@ type Modeler<T> = (injects?: Injects<T>) => T
 //
 // @ exports
 
-export { KeyMap, R, A1, A2, RR, RA1, Types, Injects, Modeler }
+export { KeyMap, R, A1, A2, RR, RA1, Types, MapHelperOption, Injects, Modeler }


### PR DESCRIPTION
# Available Feature

Added map helper type guard. This will only provide method TYPO guard.

### @ examples/src/store/modules/counter.ts

```javascript
// ______________________________________________________
//
// @ Getters

const getters = {
  nameLabel(state: CounterState): string {
    return `my name is ${state.name}`
  }
}
const { proxyMapGetters } = fromGetters(getters, namespace)

// ______________________________________________________
//
// @ Mutations

const mutations = {
  increment(state: CounterState): void {
    state.count++
  },
  decrement(state: CounterState): void {
    state.count--
  }
}
const { proxyMapMutations } = fromMutations(mutations, namespace)

// ______________________________________________________
//
// @ Actions

const actions = {
  async asyncIncrement({ commit }: { commit: Function }, duration: number) {
    await wait(duration)
    committers.increment(commit)
  }
}
const { proxyMapActions } = fromActions(actions, namespace)

```

### @ examples/src/vue/app.vue

```javascript
import { mapGetters, mapMutations, mapActions } from 'vuex'
import {
  proxyMapGetters,
  proxyMapMutations,
  proxyMapActions
} from '../store/modules/counter'

const computed: ThisType<BoundsStore> = {
  ...proxyMapGetters(mapGetters, ['nameLabel'])
}
const methods: ThisType<BoundsStore> = {
  ...proxyMapMutations(mapMutations, ['increment', 'decrement']),
  ...proxyMapActions(mapActions, ['asyncIncrement'])
}
```
