### PR TITLE
Add mapState proxy

### DIFF
--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -1,15 +1,18 @@
 import {
+  fromState,
   fromMutations,
   fromActions,
   fromGetters,
   Injects,
   Modeler
-} from 'vuex-aggregate'
+} from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
 //
 // @ Model
+
+const namespace = 'counter'
 
 interface State {
   count: number
@@ -22,7 +25,7 @@ const Model: Modeler<State> = injects => ({
   isRunningAutoIncrement: false,
   ...injects
 })
-const namespace = 'counter'
+const { proxyMapState } = fromState(Model(), namespace)
 
 // ______________________________________________________
 //
@@ -121,6 +124,7 @@ export {
   actionTypes,
   committers,
   dispatchers,
+  proxyMapState,
   proxyGetters,
   proxyMapGetters,
   proxyMapMutations,

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
-    <p>count = {{countLabel}}</p>
+    <p>count = {{count}}</p>
+    <p>double = {{double}}</p>
     <p>expo2 = {{expo2}}</p>
+    <p>countLabel = {{countLabel}}</p>
     <p>isRunningAutoIncrement = {{autoIncrementLabel}}</p>
     <p>name = {{nameLabel}}</p>
     <div>
@@ -18,11 +20,17 @@
 
 <script lang='ts'>
 import Vue from 'vue'
-import { mapGetters, mapMutations, mapActions } from 'vuex'
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex'
 import { BoundsStore } from '../store/index'
 import * as Counter from '../store/modules/counter'
 
 const computed: ThisType<BoundsStore> = {
+  ...Counter.proxyMapState(mapState, [
+    'count'
+  ]),
+  ...Counter.proxyMapState(mapState, {
+    double: state => state.count * 2
+  }),
   ...Counter.proxyMapGetters(mapGetters, ['nameLabel', 'autoIncrementLabel']),
   countLabel() {
     return Counter.proxyGetters.countLabel(this.$store.getters, 'pt')

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -25,9 +25,7 @@ import { BoundsStore } from '../store/index'
 import * as Counter from '../store/modules/counter'
 
 const computed: ThisType<BoundsStore> = {
-  ...Counter.proxyMapState(mapState, [
-    'count'
-  ]),
+  ...Counter.proxyMapState(mapState, ['count']),
   ...Counter.proxyMapState(mapState, {
     double: state => state.count * 2
   }),

--- a/src/fromState.ts
+++ b/src/fromState.ts
@@ -1,0 +1,32 @@
+import { KeyMap } from '../typings/utils.d'
+import {
+  FromStateReturn,
+  ProxyMapState,
+  MapStateHelperOption
+} from '../typings/fromState.d'
+
+const namespaced: KeyMap = {}
+
+function fromState<T>(state: T, namespace: string): FromStateReturn<T> {
+  if (
+    namespaced[namespace] !== undefined &&
+    process.env.NODE_ENV !== 'development'
+  ) {
+    throw new Error(
+      `vuex-aggregate: conflict fromState namespace -> ${namespace}${state}`
+    )
+  } else {
+    namespaced[namespace] = namespace
+  }
+  function proxyMapState<H extends Function, O extends MapStateHelperOption<T>>(
+    mapHelper: H,
+    mapHelperOption: O
+  ) {
+    return mapHelper(namespace, mapHelperOption)
+  }
+  return {
+    proxyMapState: proxyMapState as ProxyMapState<T>
+  }
+}
+
+export { fromState }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Injects, Modeler } from './utils'
+import { fromState } from './fromState'
 import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
 import { fromActions } from './fromActions'
-export { fromGetters, fromMutations, fromActions, Injects, Modeler }
+export { fromState, fromGetters, fromMutations, fromActions, Injects, Modeler }

--- a/typings/fromState.d.ts
+++ b/typings/fromState.d.ts
@@ -1,0 +1,26 @@
+// ______________________________________________________
+//
+// @ fromState
+
+type StateGetter<T> = (state: T) => any
+type MapStateHelperOption<T> =
+  | Array<keyof T>
+  | { [k: string]: keyof T | StateGetter<T> }
+
+type ProxyMapState<T> = (
+  mapState: Function,
+  mapStateHelperOption: MapStateHelperOption<T>
+) => any
+
+interface FromStateReturn<T> {
+  readonly proxyMapState: ProxyMapState<T>
+}
+
+// DECL
+declare function fromState<T>(state: T, namespace: string): FromStateReturn<T>
+
+// ______________________________________________________
+//
+// @ exports
+
+export { MapStateHelperOption, ProxyMapState, FromStateReturn, fromState }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,10 +1,11 @@
-import { Injects, Modeler } from './utils'
+import { fromState } from './fromState'
 import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
 import { fromActions } from './fromActions'
+import { Injects, Modeler } from './utils'
 
 // ______________________________________________________
 //
 // @ exports
 
-export { Injects, Modeler, fromGetters, fromMutations, fromActions }
+export { fromState, fromGetters, fromMutations, fromActions, Injects, Modeler }


### PR DESCRIPTION
# Available Feature

Added mapState helper type guard. This will provide string literal accessor and map state function.

### @ examples/src/store/modules/counter.ts

```javascript
// ______________________________________________________
//
// @ Model

const Model: Modeler<State> = injects => ({
  count: 0,
  name: 'unknown',
  isRunningAutoIncrement: false,
  ...injects
})
const { proxyMapState } = fromState(Model(), namespace)


```

### @ examples/src/vue/app.vue

```javascript
import { mapState } from 'vuex'
import { proxyMapState } from '../store/modules/counter'

const computed: ThisType<BoundsStore> = {
  ...proxyMapState(mapState, ['count']),
  ...proxyMapState(mapState, {
    double: state => state.count * 2
  })
}
```
