### PR TITLE
Assign store instance

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -29,15 +29,15 @@ const mutations = {
     state.name = name
   }
 }
-const { inferCommits, mutationTypes } = fromMutations(mutations, namespace)
+const { commits, mutationTypes } = fromMutations(mutations, namespace)
 
 const actions = {
   async asyncIncrement({ commit }, duration) {
-    inferCommits.increment(commit)
+    commits.increment(commit)
     return 'asyncIncrement called'
   }
 }
-const { inferDispatches, actionTypes } = fromActions(actions, namespace)
+const { dispatches, actionTypes } = fromActions(actions, namespace)
 
 const CounterModule = injects => ({
   namespaced: true,
@@ -67,11 +67,11 @@ describe('vuex-aggregate', () => {
     test('action types has namespaced value', () => {
       expect(actionTypes.asyncIncrement).toEqual(`${namespace}/asyncIncrement`)
     })
-    test('inferCommits has function', () => {
-      expect(typeof inferCommits.increment === 'function').toBe(true)
+    test('commits has function', () => {
+      expect(typeof commits.increment === 'function').toBe(true)
     })
-    test('inferDispatches has function', () => {
-      expect(typeof inferDispatches.asyncIncrement === 'function').toBe(true)
+    test('dispatches has function', () => {
+      expect(typeof dispatches.asyncIncrement === 'function').toBe(true)
     })
   })
 
@@ -79,7 +79,7 @@ describe('vuex-aggregate', () => {
     const store = createStore()
     test('count will be increment', () => {
       expect(store.state.counter.count).toEqual(0)
-      inferCommits.increment(store.commit)
+      commits.increment(store.commit)
       expect(store.state.counter.count).toEqual(1)
     })
   })
@@ -87,7 +87,7 @@ describe('vuex-aggregate', () => {
   describe('committer return void', () => {
     const store = createStore()
     test('commiter will return undefined', () => {
-      const commitReturn = inferCommits.increment(store.commit)
+      const commitReturn = commits.increment(store.commit)
       expect(commitReturn).toEqual(undefined)
     })
   })
@@ -96,7 +96,7 @@ describe('vuex-aggregate', () => {
     const store = createStore()
     test('count will be increment', () => {
       expect(store.state.counter.count).toEqual(0)
-      inferDispatches.asyncIncrement(store.dispatch)
+      dispatches.asyncIncrement(store.dispatch)
       expect(store.state.counter.count).toEqual(1)
     })
   })
@@ -104,7 +104,7 @@ describe('vuex-aggregate', () => {
   describe('dispatcher return Promise', () => {
     const store = createStore()
     test('promise resolve then return value', async () => {
-      const dispatchReturn = await inferDispatches.asyncIncrement(store.dispatch)
+      const dispatchReturn = await dispatches.asyncIncrement(store.dispatch)
       expect(dispatchReturn).toEqual('asyncIncrement called')
     })
   })

--- a/examples/src/store/index.ts
+++ b/examples/src/store/index.ts
@@ -1,21 +1,19 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
+import * as VuexAggregate from '../../../src'
 import * as Counter from './modules/counter'
 
 // ______________________________________________________
 //
 // @ Types
 
-export interface StoreState {
+interface StoreState {
   counter: Counter.State
 }
-export interface Store {
+interface Store {
   state: StoreState
-  commit: Function
-  dispatch: Function
-  getters: any
 }
-export interface BoundsStore {
+interface BoundsStore {
   $store: Store
 }
 
@@ -23,8 +21,12 @@ export interface BoundsStore {
 
 Vue.use(Vuex)
 
-export const store = new Vuex.Store({
+const store = new Vuex.Store({
   modules: {
     [Counter.namespace]: Counter.moduleFactory({ name: 'COUNTER' })
   }
 })
+
+VuexAggregate.use(store)
+
+export { StoreState, Store, BoundsStore, store }

--- a/examples/src/store/index.ts
+++ b/examples/src/store/index.ts
@@ -4,20 +4,6 @@ import * as VuexAggregate from '../../../src'
 import * as Counter from './modules/counter'
 
 // ______________________________________________________
-//
-// @ Types
-
-interface StoreState {
-  counter: Counter.State
-}
-interface Store {
-  state: StoreState
-}
-interface BoundsStore {
-  $store: Store
-}
-
-// ______________________________________________________
 
 Vue.use(Vuex)
 
@@ -27,6 +13,6 @@ const store = new Vuex.Store({
   }
 })
 
-VuexAggregate.use(store)
+VuexAggregate.use(store) // Required
 
-export { StoreState, Store, BoundsStore, store }
+export { store }

--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -4,13 +4,13 @@ import {
   fromActions,
   fromGetters,
   Injects,
-  Modeler
+  StateFactory
 } from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
 //
-// @ Model
+// @ State
 
 const namespace = 'counter'
 
@@ -19,19 +19,19 @@ interface State {
   name: string
   isRunningAutoIncrement: boolean
 }
-const Model: Modeler<State> = injects => ({
+const stateFactory: StateFactory<State> = injects => ({
   count: 0,
   name: 'unknown',
   isRunningAutoIncrement: false,
   ...injects
 })
-const { inferMapState } = fromState(Model(), namespace)
+const { mapState } = fromState(stateFactory(), namespace)
 
 // ______________________________________________________
 //
 // @ Getters
 
-const getters = {
+const _getters = {
   nameLabel(state: State): string {
     return `my name is ${state.name}`
   },
@@ -50,7 +50,7 @@ const getters = {
     }
   }
 }
-const { inferGetters, inferMapGetters } = fromGetters(getters, namespace)
+const { getters, mapGetters } = fromGetters(_getters, namespace)
 
 // ______________________________________________________
 //
@@ -73,7 +73,7 @@ const mutations = {
     state.isRunningAutoIncrement = flag
   }
 }
-const { mutationTypes, inferCommits, inferMapMutations } = fromMutations(
+const { commits, mutationTypes, mapMutations } = fromMutations(
   mutations,
   namespace
 )
@@ -83,26 +83,24 @@ const { mutationTypes, inferCommits, inferMapMutations } = fromMutations(
 // @ Actions
 
 const actions = {
-  async asyncIncrement(context: any, duration: number) {
-    await wait(duration)
-    inferCommits.increment()
+  async asyncIncrement() {
+    await wait(1000)
+    commits.increment()
   },
   async toggleAutoIncrement(
     { state }: { state: State },
-    { duration, flag }: { duration: number; flag: boolean }
+    { duration }: { duration: number }
   ) {
-    inferCommits.setRunningAutoIncrement(flag)
+    const flag = !state.isRunningAutoIncrement
+    commits.setRunningAutoIncrement(flag)
     while (true) {
       if (!state.isRunningAutoIncrement) break
       await wait(duration)
-      inferCommits.increment()
+      commits.increment()
     }
   }
 }
-const { actionTypes, inferDispatches, inferMapActions } = fromActions(
-  actions,
-  namespace
-)
+const { dispatches, actionTypes, mapActions } = fromActions(actions, namespace)
 
 // ______________________________________________________
 //
@@ -110,8 +108,8 @@ const { actionTypes, inferDispatches, inferMapActions } = fromActions(
 
 const moduleFactory = (injects?: Injects<State>) => ({
   namespaced: true, // Required
-  state: Model(injects),
-  getters,
+  state: stateFactory(injects),
+  getters: _getters,
   mutations,
   actions
 })
@@ -122,11 +120,11 @@ export {
   moduleFactory,
   mutationTypes,
   actionTypes,
-  inferCommits as commits,
-  inferDispatches as dispatches,
-  inferMapState as mapState,
-  inferGetters as getters,
-  inferMapGetters as mapGetters,
-  inferMapMutations as mapMutations,
-  inferMapActions as mapActions
+  commits,
+  dispatches,
+  mapState,
+  getters,
+  mapGetters,
+  mapMutations,
+  mapActions
 }

--- a/examples/src/store/modules/counter.ts
+++ b/examples/src/store/modules/counter.ts
@@ -5,7 +5,7 @@ import {
   fromGetters,
   Injects,
   Modeler
-} from 'vuex-aggregate'
+} from '../../../../src'
 import { wait } from '../../utils/promise'
 
 // ______________________________________________________
@@ -83,19 +83,19 @@ const { mutationTypes, inferCommits, inferMapMutations } = fromMutations(
 // @ Actions
 
 const actions = {
-  async asyncIncrement({ commit }: { commit: Function }, duration: number) {
+  async asyncIncrement(context: any, duration: number) {
     await wait(duration)
-    inferCommits.increment(commit)
+    inferCommits.increment()
   },
   async toggleAutoIncrement(
-    { commit, state }: { commit: Function; state: State },
+    { state }: { state: State },
     { duration, flag }: { duration: number; flag: boolean }
   ) {
-    inferCommits.setRunningAutoIncrement(commit, flag)
+    inferCommits.setRunningAutoIncrement(flag)
     while (true) {
       if (!state.isRunningAutoIncrement) break
       await wait(duration)
-      inferCommits.increment(commit)
+      inferCommits.increment()
     }
   }
 }
@@ -128,5 +128,5 @@ export {
   inferGetters as getters,
   inferMapGetters as mapGetters,
   inferMapMutations as mapMutations,
-  inferMapActions as mapActions,
+  inferMapActions as mapActions
 }

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -9,7 +9,7 @@
     <div>
       <button @click="increment()">+1</button>
       <button @click="decrement()">-1</button>
-      <button @click="asyncIncrement(1000)">asyncIncrement</button>
+      <button @click="asyncIncrement()">asyncIncrement</button>
       <button @click="toggleAutoIncrement(100)">toggleAutoIncrement</button>
     </div>
     <div>
@@ -20,10 +20,9 @@
 
 <script lang='ts'>
 import Vue from 'vue'
-import { BoundsStore } from '../store/index'
 import * as Counter from '../store/modules/counter'
 
-const computed: ThisType<BoundsStore> = {
+const computed = {
   ...Counter.mapState(['count']),
   ...Counter.mapState({
     double: state => state.count * 2
@@ -37,18 +36,14 @@ const computed: ThisType<BoundsStore> = {
   }
 }
 
-const methods: ThisType<BoundsStore> = {
+const methods = {
   ...Counter.mapMutations(['increment', 'decrement']),
   ...Counter.mapActions(['asyncIncrement']),
   setName(value: string) {
     Counter.commits.setName(value)
   },
   toggleAutoIncrement(duration: number) {
-    const flag = !this.$store.state.counter.isRunningAutoIncrement
-    Counter.dispatches.toggleAutoIncrement({
-      duration,
-      flag
-    })
+    Counter.dispatches.toggleAutoIncrement({ duration })
   }
 }
 

--- a/examples/src/vue/app.vue
+++ b/examples/src/vue/app.vue
@@ -30,10 +30,10 @@ const computed: ThisType<BoundsStore> = {
   }),
   ...Counter.mapGetters(['nameLabel', 'autoIncrementLabel']),
   countLabel() {
-    return Counter.getters.countLabel(this.$store.getters, 'pt')
+    return Counter.getters.countLabel('pt')
   },
   expo2() {
-    return Counter.getters.expo(this.$store.getters, 2)
+    return Counter.getters.expo(2)
   }
 }
 
@@ -41,11 +41,11 @@ const methods: ThisType<BoundsStore> = {
   ...Counter.mapMutations(['increment', 'decrement']),
   ...Counter.mapActions(['asyncIncrement']),
   setName(value: string) {
-    Counter.commits.setName(this.$store.commit, value)
+    Counter.commits.setName(value)
   },
   toggleAutoIncrement(duration: number) {
     const flag = !this.$store.state.counter.isRunningAutoIncrement
-    Counter.dispatches.toggleAutoIncrement(this.$store.dispatch, {
+    Counter.dispatches.toggleAutoIncrement({
       duration,
       flag
     })

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitThis": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "lib": [
       "dom",
       "es5",

--- a/src/fromActions.ts
+++ b/src/fromActions.ts
@@ -1,4 +1,5 @@
 import { mapActions } from 'vuex'
+import { store } from './utils'
 import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
 import {
   Actions,
@@ -28,8 +29,8 @@ function fromActions<T extends KeyMap & Actions<T>>(
   Object.keys(actions).forEach(key => {
     const type = `${namespace}/${key}`
     actionTypes[key] = type
-    inferDispatches[key] = (dispatch: Function, payload?: any) => {
-      return dispatch(type, payload, { root: true })
+    inferDispatches[key] = (payload?: any) => {
+      return store.dispatch(type, payload, { root: true })
     }
   })
   function inferMapActions<O extends MapHelperOption<T>>(mapHelperOption: O) {

--- a/src/fromActions.ts
+++ b/src/fromActions.ts
@@ -1,10 +1,10 @@
 import { mapActions } from 'vuex'
 import { store } from './utils'
-import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
+import { Types, MapOption, KeyMap } from '../typings/utils.d'
 import {
   Actions,
-  InferDispatches,
-  InferMapActions,
+  Dispatches,
+  MapActions,
   FromActionsReturn
 } from '../typings/fromActions.d'
 
@@ -25,22 +25,22 @@ function fromActions<T extends KeyMap & Actions<T>>(
     namespaced[namespace] = namespace
   }
   const actionTypes: KeyMap = {}
-  const inferDispatches: KeyMap = {}
+  const dispatches: KeyMap = {}
   Object.keys(actions).forEach(key => {
     const type = `${namespace}/${key}`
     actionTypes[key] = type
-    inferDispatches[key] = (payload?: any) => {
+    dispatches[key] = (payload?: any) => {
       return store.dispatch(type, payload, { root: true })
     }
   })
-  function inferMapActions<O extends MapHelperOption<T>>(mapHelperOption: O) {
+  function _mapActions<O extends MapOption<T>>(mapOption: O) {
     const mapper = mapActions as any
-    return mapper(namespace, mapHelperOption)
+    return mapper(namespace, mapOption)
   }
   return {
     actionTypes: actionTypes as Types<T>,
-    inferDispatches: inferDispatches as InferDispatches<T>,
-    inferMapActions: inferMapActions as InferMapActions<T>
+    dispatches: dispatches as Dispatches<T>,
+    mapActions: _mapActions as MapActions<T>
   }
 }
 

--- a/src/fromGetters.ts
+++ b/src/fromGetters.ts
@@ -1,16 +1,16 @@
 import { mapGetters } from 'vuex'
 import { store } from './utils'
-import { KeyMap, MapHelperOption } from '../typings/utils.d'
+import { KeyMap, MapOption } from '../typings/utils.d'
 import {
+  IGetters,
   Getters,
-  InferGetters,
-  InferMapGetters,
+  MapGetters,
   FromGettersReturn
 } from '../typings/fromGetters.d'
 
 const namespaced: KeyMap = {}
 
-function fromGetters<T extends KeyMap & Getters<T>>(
+function fromGetters<T extends KeyMap & IGetters<T>>(
   getters: T,
   namespace: string
 ): FromGettersReturn<T> {
@@ -24,22 +24,22 @@ function fromGetters<T extends KeyMap & Getters<T>>(
   } else {
     namespaced[namespace] = namespace
   }
-  const inferGetters: KeyMap = {}
+  const _getters: KeyMap = {}
   Object.keys(getters).forEach(key => {
     const getterKey = `${namespace}/${key}`
-    inferGetters[key] = (args?: any) => {
+    _getters[key] = (args?: any) => {
       if (typeof store.getters[getterKey] !== 'function')
         return store.getters[getterKey]
       return store.getters[getterKey](args)
     }
   })
-  function inferMapGetters<O extends MapHelperOption<T>>(mapHelperOption: O) {
+  function _mapGetters<O extends MapOption<T>>(mapOption: O) {
     const mapper = mapGetters as any
-    return mapper(namespace, mapHelperOption)
+    return mapper(namespace, mapOption)
   }
   return {
-    inferGetters: inferGetters as InferGetters<T>,
-    inferMapGetters: inferMapGetters as InferMapGetters<T>
+    getters: _getters as Getters<T>,
+    mapGetters: _mapGetters as MapGetters<T>
   }
 }
 

--- a/src/fromGetters.ts
+++ b/src/fromGetters.ts
@@ -1,4 +1,5 @@
 import { mapGetters } from 'vuex'
+import { store } from './utils'
 import { KeyMap, MapHelperOption } from '../typings/utils.d'
 import {
   Getters,
@@ -26,9 +27,10 @@ function fromGetters<T extends KeyMap & Getters<T>>(
   const inferGetters: KeyMap = {}
   Object.keys(getters).forEach(key => {
     const getterKey = `${namespace}/${key}`
-    inferGetters[key] = (state: KeyMap, args?: any) => {
-      if (typeof state[getterKey] !== 'function') return state[getterKey]
-      return state[getterKey](args)
+    inferGetters[key] = (args?: any) => {
+      if (typeof store.getters[getterKey] !== 'function')
+        return store.getters[getterKey]
+      return store.getters[getterKey](args)
     }
   })
   function inferMapGetters<O extends MapHelperOption<T>>(mapHelperOption: O) {

--- a/src/fromMutations.ts
+++ b/src/fromMutations.ts
@@ -1,4 +1,5 @@
 import { mapMutations } from 'vuex'
+import { store } from './utils'
 import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
 import {
   Mutations,
@@ -28,8 +29,8 @@ function fromMutations<T extends KeyMap & Mutations<T>>(
   Object.keys(mutations).forEach(key => {
     const type = `${namespace}/${key}`
     mutationTypes[key] = type
-    inferCommits[key] = (commit: Function, payload?: any) => {
-      return commit(type, payload, { root: true })
+    inferCommits[key] = (payload?: any) => {
+      return store.commit(type, payload, { root: true })
     }
   })
   function inferMapMutations<O extends MapHelperOption<T>>(mapHelperOption: O) {

--- a/src/fromMutations.ts
+++ b/src/fromMutations.ts
@@ -1,10 +1,10 @@
 import { mapMutations } from 'vuex'
 import { store } from './utils'
-import { Types, MapHelperOption, KeyMap } from '../typings/utils.d'
+import { Types, MapOption, KeyMap } from '../typings/utils.d'
 import {
   Mutations,
-  InferCommits,
-  InferMapMutations,
+  Commits,
+  MapMutations,
   FromMutationsReturn
 } from '../typings/fromMutations.d'
 
@@ -25,22 +25,22 @@ function fromMutations<T extends KeyMap & Mutations<T>>(
     namespaced[namespace] = namespace
   }
   const mutationTypes: KeyMap = {}
-  const inferCommits: KeyMap = {}
+  const commits: KeyMap = {}
   Object.keys(mutations).forEach(key => {
     const type = `${namespace}/${key}`
     mutationTypes[key] = type
-    inferCommits[key] = (payload?: any) => {
+    commits[key] = (payload?: any) => {
       return store.commit(type, payload, { root: true })
     }
   })
-  function inferMapMutations<O extends MapHelperOption<T>>(mapHelperOption: O) {
+  function _mapMutations<O extends MapOption<T>>(mapOption: O) {
     const mapper = mapMutations as any
-    return mapper(namespace, mapHelperOption)
+    return mapper(namespace, mapOption)
   }
   return {
     mutationTypes: mutationTypes as Types<T>,
-    inferCommits: inferCommits as InferCommits<T>,
-    inferMapMutations: inferMapMutations as InferMapMutations<T>
+    commits: commits as Commits<T>,
+    mapMutations: _mapMutations as MapMutations<T>
   }
 }
 

--- a/src/fromState.ts
+++ b/src/fromState.ts
@@ -2,8 +2,8 @@ import { mapState } from 'vuex'
 import { KeyMap } from '../typings/utils.d'
 import {
   FromStateReturn,
-  InferMapState,
-  MapStateHelperOption
+  MapState,
+  MapStateOption
 } from '../typings/fromState.d'
 
 const namespaced: KeyMap = {}
@@ -19,14 +19,14 @@ function fromState<T>(state: T, namespace: string): FromStateReturn<T> {
   } else {
     namespaced[namespace] = namespace
   }
-  function inferMapState<O extends MapStateHelperOption<T>>(
-    mapHelperOption: O
+  function _mapState<O extends MapStateOption<T>>(
+    mapOption: O
   ) {
     const mapper = mapState as any
-    return mapper(namespace, mapHelperOption)
+    return mapper(namespace, mapOption)
   }
   return {
-    inferMapState: inferMapState as InferMapState<T>
+    mapState: _mapState as MapState<T>
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
-import { Injects, Modeler } from './utils'
+import { Injects, Modeler, use } from './utils'
 import { fromState } from './fromState'
 import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
 import { fromActions } from './fromActions'
-export { fromState, fromGetters, fromMutations, fromActions, Injects, Modeler }
+
+export {
+  fromState,
+  fromGetters,
+  fromMutations,
+  fromActions,
+  use,
+  Injects,
+  Modeler
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Injects, Modeler, use } from './utils'
+import { Injects, StateFactory, use } from './utils'
 import { fromState } from './fromState'
 import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
@@ -11,5 +11,5 @@ export {
   fromActions,
   use,
   Injects,
-  Modeler
+  StateFactory
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,13 @@
 type Injects<T> = { [P in keyof T]?: T[P] }
 type Modeler<T> = (injects?: Injects<T>) => T
-
-export { Injects, Modeler }
+interface Store {
+  state: any
+  commit: Function
+  dispatch: Function
+  getters: any
+}
+let store: Store = null
+function use(_store: any) {
+  store = _store as Store
+}
+export { Injects, Modeler, use, store }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 type Injects<T> = { [P in keyof T]?: T[P] }
-type Modeler<T> = (injects?: Injects<T>) => T
+type StateFactory<T> = (injects?: Injects<T>) => T
 interface Store {
   state: any
   commit: Function
@@ -10,4 +10,4 @@ let store: Store = null
 function use(_store: any) {
   store = _store as Store
 }
-export { Injects, Modeler, use, store }
+export { Injects, StateFactory, use, store }

--- a/typings/fromActions.d.ts
+++ b/typings/fromActions.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, A2, Types, MapHelperOption } from './utils.d'
+import { KeyMap, A2, Types, MapOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -14,12 +14,12 @@ type Actions<T> = { [K in keyof T]: Action<T[K]> }
 type DP<T> = () => Promise<any>
 type DPPL<T> = (payload: A2<T>) => Promise<any>
 type Dispatcher<T> = T extends AC<T> ? DP<T> : DPPL<T>
-type InferDispatches<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
-type InferMapActions<T> = (mapHelperOption: MapHelperOption<T>) => any
+type Dispatches<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
+type MapActions<T> = (mapOption: MapOption<T>) => any
 interface FromActionsReturn<A> {
   readonly actionTypes: Types<A>
-  readonly inferDispatches: InferDispatches<A>
-  readonly inferMapActions: InferMapActions<A>
+  readonly dispatches: Dispatches<A>
+  readonly mapActions: MapActions<A>
 }
 
 // DECL
@@ -34,8 +34,8 @@ declare function fromActions<T extends KeyMap & Actions<T>>(
 
 export {
   Actions,
-  InferDispatches,
-  InferMapActions,
+  Dispatches,
+  MapActions,
   FromActionsReturn,
   fromActions
 }

--- a/typings/fromActions.d.ts
+++ b/typings/fromActions.d.ts
@@ -11,8 +11,8 @@ type Action<T> = AC<T> | ACPL<T>
 type Actions<T> = { [K in keyof T]: Action<T[K]> }
 
 // OUT
-type DP<T> = (diapatch: Function) => Promise<any>
-type DPPL<T> = (diapatch: Function, payload: A2<T>) => Promise<any>
+type DP<T> = () => Promise<any>
+type DPPL<T> = (payload: A2<T>) => Promise<any>
 type Dispatcher<T> = T extends AC<T> ? DP<T> : DPPL<T>
 type InferDispatches<T> = { readonly [K in keyof T]: Dispatcher<T[K]> }
 type InferMapActions<T> = (mapHelperOption: MapHelperOption<T>) => any

--- a/typings/fromGetters.d.ts
+++ b/typings/fromGetters.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, RA1, R, RR, Types, MapHelperOption } from './utils.d'
+import { KeyMap, RA1, R, RR, Types, MapOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -8,22 +8,22 @@ import { KeyMap, RA1, R, RR, Types, MapHelperOption } from './utils.d'
 type GT<T> = (contextGetters?: any) => any
 type GTR<T> = (contextGetters?: any) => (args: any) => any
 type Getter<T> = GT<T> | GTR<T>
-type Getters<T> = { [K in keyof T]: Getter<T[K]> }
+type IGetters<T> = { [K in keyof T]: Getter<T[K]> }
 
 // OUT
 type PGT<T> = () => R<T>
 type PGTR<T> = (args: RA1<T>) => RR<T>
 type ProxyGetter<T> = T extends GTR<T> ? PGTR<T> : PGT<T>
-type InferGetters<T> = { readonly [K in keyof T]: ProxyGetter<T[K]> }
-type InferMapGetters<T> = (mapHelperOption: MapHelperOption<T>) => any
+type Getters<T> = { readonly [K in keyof T]: ProxyGetter<T[K]> }
+type MapGetters<T> = (mapOption: MapOption<T>) => any
 
 interface FromGettersReturn<G> {
-  readonly inferGetters: InferGetters<G>
-  readonly inferMapGetters: InferMapGetters<G>
+  readonly getters: Getters<G>
+  readonly mapGetters: MapGetters<G>
 }
 
 // DECL
-declare function fromGetters<T extends KeyMap & Getters<T>>(
+declare function fromGetters<T extends KeyMap & IGetters<T>>(
   getters: T,
   namespace: string
 ): FromGettersReturn<T>
@@ -33,9 +33,9 @@ declare function fromGetters<T extends KeyMap & Getters<T>>(
 // @ exports
 
 export {
+  IGetters,
   Getters,
-  InferGetters,
-  InferMapGetters,
+  MapGetters,
   FromGettersReturn,
   fromGetters
 }

--- a/typings/fromGetters.d.ts
+++ b/typings/fromGetters.d.ts
@@ -5,14 +5,14 @@ import { KeyMap, RA1, R, RR, Types, MapHelperOption } from './utils.d'
 // @ fromGetters
 
 // IN
-type GT<T> = (getters: any, contextGetters?: any) => any
-type GTR<T> = (getters: any, contextGetters?: any) => (args: any) => any
+type GT<T> = (contextGetters?: any) => any
+type GTR<T> = (contextGetters?: any) => (args: any) => any
 type Getter<T> = GT<T> | GTR<T>
 type Getters<T> = { [K in keyof T]: Getter<T[K]> }
 
 // OUT
-type PGT<T> = (getters: any) => R<T>
-type PGTR<T> = (getters: any, args: RA1<T>) => RR<T>
+type PGT<T> = () => R<T>
+type PGTR<T> = (args: RA1<T>) => RR<T>
 type ProxyGetter<T> = T extends GTR<T> ? PGTR<T> : PGT<T>
 type InferGetters<T> = { readonly [K in keyof T]: ProxyGetter<T[K]> }
 type InferMapGetters<T> = (mapHelperOption: MapHelperOption<T>) => any

--- a/typings/fromMutations.d.ts
+++ b/typings/fromMutations.d.ts
@@ -11,8 +11,8 @@ type Mutation<T> = MT<T> | MTPL<T>
 type Mutations<T> = { [K in keyof T]: Mutation<T[K]> }
 
 // OUT
-type CM<T> = (commit: Function) => void
-type CMPL<T> = (commit: Function, payload: A2<T>) => void
+type CM<T> = () => void
+type CMPL<T> = (payload: A2<T>) => void
 type Committer<T> = T extends MT<T> ? CM<T> : CMPL<T>
 type InferCommits<T> = { readonly [K in keyof T]: Committer<T[K]> }
 type InferMapMutations<T> = (mapHelperOption: MapHelperOption<T>) => any

--- a/typings/fromMutations.d.ts
+++ b/typings/fromMutations.d.ts
@@ -1,4 +1,4 @@
-import { KeyMap, A1, A2, Types, MapHelperOption } from './utils.d'
+import { KeyMap, A1, A2, Types, MapOption } from './utils.d'
 
 // ______________________________________________________
 //
@@ -14,12 +14,12 @@ type Mutations<T> = { [K in keyof T]: Mutation<T[K]> }
 type CM<T> = () => void
 type CMPL<T> = (payload: A2<T>) => void
 type Committer<T> = T extends MT<T> ? CM<T> : CMPL<T>
-type InferCommits<T> = { readonly [K in keyof T]: Committer<T[K]> }
-type InferMapMutations<T> = (mapHelperOption: MapHelperOption<T>) => any
+type Commits<T> = { readonly [K in keyof T]: Committer<T[K]> }
+type MapMutations<T> = (mapOption: MapOption<T>) => any
 interface FromMutationsReturn<T> {
   readonly mutationTypes: Types<T>
-  readonly inferCommits: InferCommits<T>
-  readonly inferMapMutations: InferMapMutations<T>
+  readonly commits: Commits<T>
+  readonly mapMutations: MapMutations<T>
 }
 
 // DECL
@@ -34,8 +34,8 @@ declare function fromMutations<T extends KeyMap & Mutations<T>>(
 
 export {
   Mutations,
-  InferCommits,
-  InferMapMutations,
+  Commits,
+  MapMutations,
   FromMutationsReturn,
   fromMutations
 }

--- a/typings/fromState.d.ts
+++ b/typings/fromState.d.ts
@@ -3,14 +3,14 @@
 // @ fromState
 
 type StateGetter<T> = (state: T) => any
-type MapStateHelperOption<T> =
+type MapStateOption<T> =
   | Array<keyof T>
   | { [k: string]: keyof T | StateGetter<T> }
 
-type InferMapState<T> = (mapStateHelperOption: MapStateHelperOption<T>) => any
+type MapState<T> = (mapStateOption: MapStateOption<T>) => any
 
 interface FromStateReturn<T> {
-  readonly inferMapState: InferMapState<T>
+  readonly mapState: MapState<T>
 }
 
 // DECL
@@ -20,4 +20,4 @@ declare function fromState<T>(state: T, namespace: string): FromStateReturn<T>
 //
 // @ exports
 
-export { MapStateHelperOption, InferMapState, FromStateReturn, fromState }
+export { MapStateOption, MapState, FromStateReturn, fromState }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,10 +2,10 @@ import { fromState } from './fromState'
 import { fromGetters } from './fromGetters'
 import { fromMutations } from './fromMutations'
 import { fromActions } from './fromActions'
-import { Injects, Modeler } from './utils'
+import { Injects, StateFactory } from './utils'
 
 // ______________________________________________________
 //
 // @ exports
 
-export { fromState, fromGetters, fromMutations, fromActions, Injects, Modeler }
+export { fromState, fromGetters, fromMutations, fromActions, Injects, StateFactory }

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -15,10 +15,10 @@ type RA1<T> = T extends (...rest: any[]) => (a1: infer I) => any ? I : never
 type Types<T> = { readonly [K in keyof T]: string }
 type MapHelperOption<T> = Array<keyof T> | { [k: string]: keyof T }
 type Injects<T> = { [P in keyof T]?: T[P] }
-type Modeler<T> = (injects?: Injects<T>) => T
+type StateFactory<T> = (injects?: Injects<T>) => T
 
 // ______________________________________________________
 //
 // @ exports
 
-export { KeyMap, R, A1, A2, RR, RA1, Types, MapHelperOption, Injects, Modeler }
+export { KeyMap, R, A1, A2, RR, RA1, Types, MapHelperOption, Injects, StateFactory }

--- a/typings/utils.d.ts
+++ b/typings/utils.d.ts
@@ -13,7 +13,7 @@ type A2<T> = T extends (a1: any, a2: infer I, ...rest: any[]) => any ? I : never
 type RA1<T> = T extends (...rest: any[]) => (a1: infer I) => any ? I : never
 
 type Types<T> = { readonly [K in keyof T]: string }
-type MapHelperOption<T> = Array<keyof T> | { [k: string]: keyof T }
+type MapOption<T> = Array<keyof T> | { [k: string]: keyof T }
 type Injects<T> = { [P in keyof T]?: T[P] }
 type StateFactory<T> = (injects?: Injects<T>) => T
 
@@ -21,4 +21,4 @@ type StateFactory<T> = (injects?: Injects<T>) => T
 //
 // @ exports
 
-export { KeyMap, R, A1, A2, RR, RA1, Types, MapHelperOption, Injects, StateFactory }
+export { KeyMap, R, A1, A2, RR, RA1, Types, MapOption, Injects, StateFactory }


### PR DESCRIPTION
To reduce verbose code, assign store instnce by `VuexAggregate.use(store)`.

